### PR TITLE
Fix Thai heading spelling on real-estate page

### DIFF
--- a/docs/real-estate/index.html
+++ b/docs/real-estate/index.html
@@ -38,7 +38,7 @@
 
         <!-- Result Section -->
         <div id="resultContainer" class="mt-5">
-            <h4>ผลลัพท์</h4>
+            <h4>ผลลัพธ์</h4>
             <table class="table table-bordered">
                 <thead class="table-dark">
                     <tr>


### PR DESCRIPTION
## Summary
- correct Thai heading spelling from `ผลลัพท์` to `ผลลัพธ์` on the real-estate page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python3 -m http.server & curl http://localhost:8000/docs/real-estate/index.html | grep -n '<h4>'`

------
https://chatgpt.com/codex/tasks/task_e_689576e31e288328aa436ede4fb8b481