### PR TITLE
Limit cookie loading to numeric inputs

### DIFF
--- a/docs/bdms/radiotherapy/index.html
+++ b/docs/bdms/radiotherapy/index.html
@@ -127,7 +127,7 @@
 
         function loadValuesFromCookie() {
             // get all the inputs
-            const inputs = document.querySelectorAll('input');
+            const inputs = document.querySelectorAll('input[type=number]');
             inputs.forEach((input) => {
                 const val = getCookie(`${input.name}`);
                 if (val !== "") {


### PR DESCRIPTION
## Summary
- Restrict loadValuesFromCookie to only read numeric inputs
- Keep clearAll functionality intact for numeric fields

## Testing
- `npm test`
- `node <<'NODE' ... >>` (jsdom: confirm no console errors, inputs cleared, modifications reset)

------
https://chatgpt.com/codex/tasks/task_e_68957ced360c832898167cb543d87b09